### PR TITLE
Add podspec for React Native 0.61+ autolink support

### DIFF
--- a/RNLocalNotifications.podspec
+++ b/RNLocalNotifications.podspec
@@ -1,0 +1,19 @@
+require 'json'
+
+package = JSON.parse(File.read(File.join(__dir__, 'package.json')))
+
+Pod::Spec.new do |s|
+s.name         = 'RNLocalNotifications'
+s.version      = package['version']
+s.summary      = package['description']
+s.homepage     = package['homepage']
+s.license      = package['license']
+s.author       = { "author" => package['author']['name'] }
+s.platform     = :ios, "9.0"
+s.source       = { :git => "https://github.com/wumke/react-native-local-notifications.git", :branch => "master" }
+s.source_files = "ios/**/*.{h,m}"
+s.requires_arc = true
+
+s.dependency "React"
+
+end


### PR DESCRIPTION
As mentioned in https://github.com/wumke/react-native-local-notifications/issues/31 by @mrblgn
Adding the podspec allows the library to work on react native 0.61+ as the auto link feature changed